### PR TITLE
feat: add Laravel 12 and PHP 8.4 support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,8 @@
 This is a laravel wrapper for BigBlueButton API
 ## Requirements
 
-- Laravel 5.5 or above.
+- PHP 8.4 or above
+- Laravel 12 or above
 
 ## Installation
 
@@ -105,6 +106,7 @@ class MeetingController extends Controller
 
 ```
 **Join a meeting**
+Pass a custom meeting name as the second argument to `join()` if you need to override the default.
 ```php
 use Djoudi\Bigbluebutton\Contracts\Meeting;
 use BigBlueButton\Parameters\JoinMeetingParameters;
@@ -129,9 +131,9 @@ class MeetingController extends Controller
      */
     public function join(Request $request)
     {
-        $meetingParams = new JoinMeetingParameters($request->meetingID, $request->meetingName, 'MyMeetingPassword');
+        $meetingParams = new JoinMeetingParameters($request->meetingID, 'Guest', 'MyMeetingPassword');
         $meetingParams->setRedirect(true);
-        $meetingUrl = $this->meeting->join($meetingParams);
+        $meetingUrl = $this->meeting->join($meetingParams, $request->meetingName);
         redirect()->setTargetUrl($meetingUrl);
     }
 
@@ -167,6 +169,70 @@ class MeetingController extends Controller
     {
         $meetingParams = new EndMeetingParameters($request->meetingID, $request->moderator_password);
         $this->meeting->close($meetingParams);
+    }
+}
+
+```
+
+**Check if a meeting is running**
+```php
+use Djoudi\Bigbluebutton\Contracts\Meeting;
+use BigBlueButton\Parameters\IsMeetingRunningParameters;
+
+class MeetingController extends Controller
+{
+    /**
+     * @var \Djoudi\Bigbluebutton\Contracts\Meeting
+     */
+    protected $meeting;
+
+    public function __construct(Meeting $meeting)
+    {
+        $this->meeting = $meeting;
+    }
+
+    public function isRunning(string $meetingID)
+    {
+        $meetingParams = new IsMeetingRunningParameters($meetingID);
+        if ($this->meeting->isRunning($meetingParams)) {
+            // Meeting is currently running
+        }
+    }
+}
+
+```
+**Manage recordings**
+
+```php
+use Djoudi\\Bigbluebutton\\Contracts\\Meeting;
+use BigBlueButton\\Parameters\\PublishRecordingsParameters;
+use BigBlueButton\\Parameters\\DeleteRecordingsParameters;
+use BigBlueButton\\Parameters\\UpdateRecordingsParameters;
+
+class RecordingController extends Controller
+{
+    public function publish(Meeting $meeting, string $recordingId)
+    {
+        $params = new PublishRecordingsParameters($recordingId, true); // false to unpublish
+        if ($meeting->publishRecordings($params)) {
+            // Recording publish state updated
+        }
+    }
+
+    public function delete(Meeting $meeting, string $recordingId)
+    {
+        $params = new DeleteRecordingsParameters($recordingId);
+        if ($meeting->deleteRecordings($params)) {
+            // Recording deleted
+        }
+    }
+
+    public function update(Meeting $meeting, string $recordingId)
+    {
+        $params = (new UpdateRecordingsParameters($recordingId))->addMeta('name', 'New name');
+        if ($meeting->updateRecordings($params)) {
+            // Recording metadata updated
+        }
     }
 }
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,10 +7,8 @@ currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| 12.x    | :white_check_mark: |
+| < 12.0  | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
             "email": "info@djoudi.net"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.1",
-        "laravel/framework": "^5.5.0|^6.0|^7.0|^8.0",
-        "bigbluebutton/bigbluebutton-api-php": "2.1.4"
+        "php": "^8.4",
+        "laravel/framework": "^12.0",
+        "bigbluebutton/bigbluebutton-api-php": "^2.3.1"
 
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,13 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": "^8.4",
+        "bigbluebutton/bigbluebutton-api-php": "^2.3.1",
         "laravel/framework": "^12.0",
-        "bigbluebutton/bigbluebutton-api-php": "^2.3.1"
-
+        "php": "^8.4"
+    },
+    "require-dev": {
+        "laravel/pint": "^1.13",
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnEmptyTestSuite="false">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/BigbluebuttonMeeting.php
+++ b/src/BigbluebuttonMeeting.php
@@ -6,12 +6,12 @@ namespace Djoudi\Bigbluebutton;
 
 use BigBlueButton\BigBlueButton;
 use BigBlueButton\Parameters\CreateMeetingParameters;
+use BigBlueButton\Parameters\DeleteRecordingsParameters;
 use BigBlueButton\Parameters\EndMeetingParameters;
 use BigBlueButton\Parameters\GetMeetingInfoParameters;
 use BigBlueButton\Parameters\GetRecordingsParameters;
 use BigBlueButton\Parameters\IsMeetingRunningParameters;
 use BigBlueButton\Parameters\JoinMeetingParameters;
-use BigBlueButton\Parameters\DeleteRecordingsParameters;
 use BigBlueButton\Parameters\PublishRecordingsParameters;
 use BigBlueButton\Parameters\UpdateRecordingsParameters;
 use Djoudi\Bigbluebutton\Contracts\Meeting;
@@ -27,8 +27,6 @@ class BigbluebuttonMeeting implements Meeting
 
     /**
      *  Return a list of all meetings.
-     *
-     * @return mixed
      */
     public function all(): mixed
     {
@@ -40,11 +38,6 @@ class BigbluebuttonMeeting implements Meeting
         return false;
     }
 
-    /**
-     * @param \BigBlueButton\Parameters\CreateMeetingParameters $meeting
-     *
-     * @return bool
-     */
     public function create(CreateMeetingParameters $meeting): bool
     {
         $response = $this->bbb->createMeeting($meeting);
@@ -58,10 +51,7 @@ class BigbluebuttonMeeting implements Meeting
     /**
      *  Join meeting.
      *
-     * @param \BigBlueButton\Parameters\JoinMeetingParameters $meeting
-     * @param string|null $meetingName Custom display name for the meeting
-     *
-     * @return string
+     * @param  string|null  $meetingName  Custom display name for the meeting
      */
     public function join(JoinMeetingParameters $meeting, ?string $meetingName = null): string
     {
@@ -75,7 +65,6 @@ class BigbluebuttonMeeting implements Meeting
     /**
      *  Returns information about the meeting.
      *
-     * @param \BigBlueButton\Parameters\GetMeetingInfoParameters $meeting
      *
      * @return bool|\SimpleXMLElement
      */
@@ -91,21 +80,12 @@ class BigbluebuttonMeeting implements Meeting
 
     /**
      *  Close meeting.
-     *
-     * @param \BigBlueButton\Parameters\EndMeetingParameters $meeting
-     *
-     * @return \BigBlueButton\Responses\EndMeetingResponse
      */
     public function close(EndMeetingParameters $meeting): \BigBlueButton\Responses\EndMeetingResponse
     {
         return $this->bbb->endMeeting($meeting);
     }
 
-    /**
-     * @param \BigBlueButton\Parameters\GetRecordingsParameters $recording
-     *
-     * @return mixed
-     */
     public function getRecording(GetRecordingsParameters $recording): mixed
     {
         $response = $this->bbb->getRecordings($recording);

--- a/src/BigbluebuttonProviderService.php
+++ b/src/BigbluebuttonProviderService.php
@@ -12,7 +12,7 @@ class BigbluebuttonProviderService extends ServiceProvider
 {
     public function boot(): void
     {
-        //Merge Config
+        // Merge Config
         $this->publishes([__DIR__.'/Config/bigbluebutton.php' => config_path('bigbluebutton.php')], 'config');
     }
 
@@ -26,7 +26,7 @@ class BigbluebuttonProviderService extends ServiceProvider
         putenv("BBB_SECURITY_SALT=$server_salt");
 
         $this->app->bind('bigbluebutton', function ($app) {
-            return new BigBlueButton();
+            return new BigBlueButton;
         });
 
         $this->app->alias('bigbluebutton', BigBlueButton::class);

--- a/src/BigbluebuttonProviderService.php
+++ b/src/BigbluebuttonProviderService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Djoudi\Bigbluebutton;
 
 use BigBlueButton\BigBlueButton;
@@ -8,13 +10,13 @@ use Illuminate\Support\ServiceProvider;
 
 class BigbluebuttonProviderService extends ServiceProvider
 {
-    public function boot()
+    public function boot(): void
     {
         //Merge Config
         $this->publishes([__DIR__.'/Config/bigbluebutton.php' => config_path('bigbluebutton.php')], 'config');
     }
 
-    public function register()
+    public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/Config/bigbluebutton.php', 'bigbluebutton');
         $server_base_url = $this->app['config']->get('bigbluebutton.BBB_SERVER_BASE_URL');

--- a/src/Config/bigbluebutton.php
+++ b/src/Config/bigbluebutton.php
@@ -4,7 +4,7 @@ return [
     /*
      * Bigbluebutton server secret
      */
-    'BBB_SECURITY_SALT'   => env('BBB_SECURITY_SALT', ''),
+    'BBB_SECURITY_SALT' => env('BBB_SECURITY_SALT', ''),
     'BBB_SERVER_BASE_URL' => env('BBB_SERVER_BASE_URL', ''),
-    'BBB_RECORD_CID' => env('')
-,];
+    'BBB_RECORD_CID' => env('BBB_RECORD_CID', ''),
+];

--- a/src/Contracts/Meeting.php
+++ b/src/Contracts/Meeting.php
@@ -8,7 +8,11 @@ use BigBlueButton\Parameters\CreateMeetingParameters;
 use BigBlueButton\Parameters\EndMeetingParameters;
 use BigBlueButton\Parameters\GetMeetingInfoParameters;
 use BigBlueButton\Parameters\GetRecordingsParameters;
+use BigBlueButton\Parameters\IsMeetingRunningParameters;
 use BigBlueButton\Parameters\JoinMeetingParameters;
+use BigBlueButton\Parameters\DeleteRecordingsParameters;
+use BigBlueButton\Parameters\PublishRecordingsParameters;
+use BigBlueButton\Parameters\UpdateRecordingsParameters;
 
 interface Meeting
 {
@@ -17,23 +21,24 @@ interface Meeting
      *
      * @return mixed
      */
-    public function all();
+    public function all(): mixed;
 
     /**
      * @param \BigBlueButton\Parameters\CreateMeetingParameters $meeting
      *
      * @return bool
      */
-    public function create(CreateMeetingParameters $meeting);
+    public function create(CreateMeetingParameters $meeting): bool;
 
     /**
      *  Join meeting.
      *
      * @param \BigBlueButton\Parameters\JoinMeetingParameters $meeting
+     * @param string|null $meetingName Custom display name for the meeting
      *
      * @return string
      */
-    public function join(JoinMeetingParameters $meeting);
+    public function join(JoinMeetingParameters $meeting, ?string $meetingName = null): string;
 
     /**
      *  Returns information about the meeting.
@@ -42,7 +47,7 @@ interface Meeting
      *
      * @return bool|\SimpleXMLElement
      */
-    public function get(GetMeetingInfoParameters $meeting);
+    public function get(GetMeetingInfoParameters $meeting): \SimpleXMLElement|false;
 
     /**
      *  Close meeting.
@@ -51,12 +56,20 @@ interface Meeting
      *
      * @return \BigBlueButton\Responses\EndMeetingResponse
      */
-    public function close(EndMeetingParameters $meeting);
+    public function close(EndMeetingParameters $meeting): \BigBlueButton\Responses\EndMeetingResponse;
 
     /**
      * @param \BigBlueButton\Parameters\GetRecordingsParameters $recording
      *
      * @return mixed
      */
-    public function getRecording(GetRecordingsParameters $recording);
+    public function getRecording(GetRecordingsParameters $recording): mixed;
+
+    public function publishRecordings(PublishRecordingsParameters $recording): bool;
+
+    public function deleteRecordings(DeleteRecordingsParameters $recording): bool;
+
+    public function updateRecordings(UpdateRecordingsParameters $recording): bool;
+
+    public function isRunning(IsMeetingRunningParameters $meeting): bool;
 }

--- a/src/Contracts/Meeting.php
+++ b/src/Contracts/Meeting.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Djoudi\Bigbluebutton\Contracts;
 
 use BigBlueButton\Parameters\CreateMeetingParameters;
+use BigBlueButton\Parameters\DeleteRecordingsParameters;
 use BigBlueButton\Parameters\EndMeetingParameters;
 use BigBlueButton\Parameters\GetMeetingInfoParameters;
 use BigBlueButton\Parameters\GetRecordingsParameters;
 use BigBlueButton\Parameters\IsMeetingRunningParameters;
 use BigBlueButton\Parameters\JoinMeetingParameters;
-use BigBlueButton\Parameters\DeleteRecordingsParameters;
 use BigBlueButton\Parameters\PublishRecordingsParameters;
 use BigBlueButton\Parameters\UpdateRecordingsParameters;
 
@@ -18,32 +18,21 @@ interface Meeting
 {
     /**
      *  Return a list of all meetings.
-     *
-     * @return mixed
      */
     public function all(): mixed;
 
-    /**
-     * @param \BigBlueButton\Parameters\CreateMeetingParameters $meeting
-     *
-     * @return bool
-     */
     public function create(CreateMeetingParameters $meeting): bool;
 
     /**
      *  Join meeting.
      *
-     * @param \BigBlueButton\Parameters\JoinMeetingParameters $meeting
-     * @param string|null $meetingName Custom display name for the meeting
-     *
-     * @return string
+     * @param  string|null  $meetingName  Custom display name for the meeting
      */
     public function join(JoinMeetingParameters $meeting, ?string $meetingName = null): string;
 
     /**
      *  Returns information about the meeting.
      *
-     * @param \BigBlueButton\Parameters\GetMeetingInfoParameters $meeting
      *
      * @return bool|\SimpleXMLElement
      */
@@ -51,18 +40,9 @@ interface Meeting
 
     /**
      *  Close meeting.
-     *
-     * @param \BigBlueButton\Parameters\EndMeetingParameters $meeting
-     *
-     * @return \BigBlueButton\Responses\EndMeetingResponse
      */
     public function close(EndMeetingParameters $meeting): \BigBlueButton\Responses\EndMeetingResponse;
 
-    /**
-     * @param \BigBlueButton\Parameters\GetRecordingsParameters $recording
-     *
-     * @return mixed
-     */
     public function getRecording(GetRecordingsParameters $recording): mixed;
 
     public function publishRecordings(PublishRecordingsParameters $recording): bool;


### PR DESCRIPTION
## Summary
- require PHP 8.4 and Laravel 12
- adopt strict typing and return types for meeting services
- expose helpers to check meetings and manage recordings
- allow custom meeting name when joining

## Testing
- `composer validate`
- `php -l src/BigbluebuttonMeeting.php`
- `php -l src/Contracts/Meeting.php`
- `php -l src/BigbluebuttonProviderService.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3168be5808328aa45983a7369a46d